### PR TITLE
ci: downgraded node version to 16

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -27,7 +27,7 @@ jobs:
       # node setup
       - uses: actions/setup-node@v2
         with:
-          node-version: '20'
+          node-version: '16'
       # python setup
       - uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
Nodejs in the server supports version 16. Thus, downgraded the version temporarily.